### PR TITLE
Fix SIZEOF_INT and SIZEOF_LONG not defined when compiling manually

### DIFF
--- a/src/DSC/DSC_User/Datastream/Calcium/calciumf.c
+++ b/src/DSC/DSC_User/Datastream/Calcium/calciumf.c
@@ -170,9 +170,9 @@ void F_FUNC(cplin,CPLIN)(long *compo,cal_int *dep,float *ti,float *tf,cal_int *i
 {
   char* cnom=fstr1(STR_PTR(nom),STR_LEN(nom));
 
-#if   !SIZEOF_INT
-#error "The macro SIZEOF_INT must be defined."
-#elif SIZEOF_INT == 4
+#if   !SIZEOF_INT && !OMNI_SIZEOF_INT
+#error "The macro SIZEOF_INT or OMNI_SIZEOF_INT must be defined."
+#elif (SIZEOF_INT && SIZEOF_INT == 4) || (OMNI_SIZEOF_INT && OMNI_SIZEOF_INT == 4)
   *err=cp_lin_fort_((void *)*compo,*dep,ti,tf,iter,cnom,*max,n,tab);
 #else
   fprintf(stderr,"End of CPLIN: %s : Can't use fortran INTEGER*4 because int C is not 32bits long on this machine.\n",
@@ -185,9 +185,9 @@ void F_FUNC(cpllg,CPLLG)(long *compo,cal_int *dep,float *ti,float *tf,cal_int *i
             cal_int *max,cal_int *n, long *tab,cal_int *err STR_PLEN(nom))
 {
   char* cnom=fstr1(STR_PTR(nom),STR_LEN(nom));
-#if   !SIZEOF_LONG
-#error "The macro SIZEOF_LONG must be defined."
-#elif SIZEOF_LONG == 8
+#if   !SIZEOF_LONG && !OMNI_SIZEOF_LONG
+#error "The macro SIZEOF_LONG or OMNI_SIZEOF_LONG must be defined."
+#elif (SIZEOF_LONG && SIZEOF_LONG == 8) || (OMNI_SIZEOF_LONG && OMNI_SIZEOF_LONG == 8)
   *err=cp_llg_fort_((void *)*compo,*dep,ti,tf,iter,cnom,*max,n,tab);
 #else
   fprintf(stderr,"End of CPLLG: %s : Can't use fortran INTEGER*8 because long C is not 64bits long on this machine.\n",
@@ -200,9 +200,9 @@ void F_FUNC(cplln,CPLLN)(long *compo,cal_int *dep,float *ti,float *tf,cal_int *i
                                     cal_int *max,cal_int *n, long *tab,cal_int *err STR_PLEN(nom))
 {
  char* cnom=fstr1(STR_PTR(nom),STR_LEN(nom));
-#if   !SIZEOF_LONG
-#error "The macro SIZEOF_LONG must be defined."
-#elif SIZEOF_LONG == 8
+#if   !SIZEOF_LONG && !OMNI_SIZEOF_LONG
+#error "The macro SIZEOF_LONG or OMNI_SIZEOF_LONG must be defined."
+#elif (SIZEOF_LONG && SIZEOF_LONG == 8) || (OMNI_SIZEOF_LONG && OMNI_SIZEOF_LONG == 8)
   *err=cp_lln_fort_((void *)*compo,*dep,ti,tf,iter,cnom,*max,n,tab);
 #else
   fprintf(stderr,"End of CPLLN: %s : Can't use fortran INTEGER*8 because long C is not 64bits long on this machine.\n",
@@ -384,9 +384,9 @@ void F_FUNC(cpein,CPEIN)(long *compo,cal_int *dep,float *ti,cal_int *iter,STR_PS
   float tti=0.;
   if(*dep == CP_TEMPS)tti=*ti;
   char* cnom=fstr1(STR_PTR(nom),STR_LEN(nom));
-#if   !SIZEOF_INT
-#error "The macro SIZEOF_INT must be defined."
-#elif SIZEOF_INT == 4
+#if   !SIZEOF_INT && !OMNI_SIZEOF_INT
+#error "The macro SIZEOF_INT or OMNI_SIZEOF_INT must be defined."
+#elif (SIZEOF_INT && SIZEOF_INT == 4) || (OMNI_SIZEOF_INT && OMNI_SIZEOF_INT == 4)
   *err=cp_ein_fort_((void *)*compo,*dep,tti,*iter,cnom,*n,tab);
 #else
   fprintf(stderr,"CPEIN: %s %f %d : Can't use fortran INTEGER*4 because int C is not 32bits long on this machine.\n",
@@ -400,9 +400,9 @@ void F_FUNC(cpelg,CPELG)(long *compo,cal_int *dep,float *ti,cal_int *iter,STR_PS
   float tti=0.;
   if(*dep == CP_TEMPS)tti=*ti;
   char* cnom=fstr1(STR_PTR(nom),STR_LEN(nom));
-#if   !SIZEOF_LONG
-#error "The macro SIZEOF_LONG must be defined."
-#elif SIZEOF_LONG == 8
+#if   !SIZEOF_LONG && !OMNI_SIZEOF_LONG
+#error "The macro SIZEOF_LONG or OMNI_SIZEOF_LONG must be defined."
+#elif (SIZEOF_LONG && SIZEOF_LONG == 8) || (OMNI_SIZEOF_LONG && OMNI_SIZEOF_LONG == 8)
   *err=cp_elg_fort_((void *)*compo,*dep,tti,*iter,cnom,*n,tab);
 #else
   fprintf(stderr,"CPELG: %s %f %d : Can't use fortran INTEGER*8 because long C is not 64bits long on this machine.\n",
@@ -416,9 +416,9 @@ void F_FUNC(cpeln,CPELN)(long *compo,cal_int *dep,float *ti,cal_int *iter,STR_PS
   float tti=0.;
   if(*dep == CP_TEMPS)tti=*ti;
   char* cnom=fstr1(STR_PTR(nom),STR_LEN(nom));
-#if   !SIZEOF_LONG
-#error "The macro SIZEOF_LONG must be defined."
-#elif SIZEOF_LONG == 8
+#if   !SIZEOF_LONG && !OMNI_SIZEOF_LONG
+#error "The macro SIZEOF_LONG or OMNI_SIZEOF_LONG must be defined."
+#elif (SIZEOF_LONG && SIZEOF_LONG == 8) || (OMNI_SIZEOF_LONG && OMNI_SIZEOF_LONG == 8)
   *err=cp_eln_fort_((void *)*compo,*dep,tti,*iter,cnom,*n,tab);
 #else
   fprintf(stderr,"CPELN: %s %f %d : Can't use fortran INTEGER*8 because long C is not 64bits long on this machine.\n",


### PR DESCRIPTION
### The issue
When compiling OmniORB and OmniORBpy manually, on some OS, we have this error throw at compilation time:

```
[ 89%] Building C object src/DSC/DSC_User/Datastream/Calcium/CMakeFiles/CalciumC.dir/calciumf.c.o
/home/xxxxxxxxxxxxxxxx/Salome/kernel/code/src/DSC/DSC_User/Datastream/Calcium/calciumf.c: In function ‘cplin_’:
/home/xxxxxxxxxxxxxxxx/Salome/kernel/code/src/DSC/DSC_User/Datastream/Calcium/calciumf.c:174:2: error: #error "The macro SIZEOF_INT must be defined."
  174 | #error "The macro SIZEOF_INT must be defined."
      |  ^~~~~
/home/xxxxxxxxxxxxxxxx/Salome/kernel/code/src/DSC/DSC_User/Datastream/Calcium/calciumf.c: In function ‘cpllg_’:
/home/xxxxxxxxxxxxxxxx/Salome/kernel/code/src/DSC/DSC_User/Datastream/Calcium/calciumf.c:189:2: error: #error "The macro SIZEOF_LONG must be defined."
  189 | #error "The macro SIZEOF_LONG must be defined."
      |  ^~~~~
/home/xxxxxxxxxxxxxxxx/Salome/kernel/code/src/DSC/DSC_User/Datastream/Calcium/calciumf.c: In function ‘cplln_’:
/home/xxxxxxxxxxxxxxxx/Salome/kernel/code/src/DSC/DSC_User/Datastream/Calcium/calciumf.c:204:2: error: #error "The macro SIZEOF_LONG must be defined."
  204 | #error "The macro SIZEOF_LONG must be defined."
      |  ^~~~~
/home/xxxxxxxxxxxxxxxx/Salome/kernel/code/src/DSC/DSC_User/Datastream/Calcium/calciumf.c: In function ‘cpein_’:
/home/xxxxxxxxxxxxxxxx/Salome/kernel/code/src/DSC/DSC_User/Datastream/Calcium/calciumf.c:388:2: error: #error "The macro SIZEOF_INT must be defined."
  388 | #error "The macro SIZEOF_INT must be defined."
      |  ^~~~~
/home/xxxxxxxxxxxxxxxx/Salome/kernel/code/src/DSC/DSC_User/Datastream/Calcium/calciumf.c: In function ‘cpelg_’:
/home/xxxxxxxxxxxxxxxx/Salome/kernel/code/src/DSC/DSC_User/Datastream/Calcium/calciumf.c:404:2: error: #error "The macro SIZEOF_LONG must be defined."
  404 | #error "The macro SIZEOF_LONG must be defined."
      |  ^~~~~
/home/xxxxxxxxxxxxxxxx/Salome/kernel/code/src/DSC/DSC_User/Datastream/Calcium/calciumf.c: In function ‘cpeln_’:
/home/xxxxxxxxxxxxxxxx/Salome/kernel/code/src/DSC/DSC_User/Datastream/Calcium/calciumf.c:420:2: error: #error "The macro SIZEOF_LONG must be defined."
  420 | #error "The macro SIZEOF_LONG must be defined."
      |  ^~~~~
make[2]: *** [src/DSC/DSC_User/Datastream/Calcium/CMakeFiles/CalciumC.dir/build.make:104 : src/DSC/DSC_User/Datastream/Calcium/CMakeFiles/CalciumC.dir/calciumf.c.o] Erreur 1
make[1]: *** [CMakeFiles/Makefile2:5704 : src/DSC/DSC_User/Datastream/Calcium/CMakeFiles/CalciumC.dir/all] Erreur 2
make: *** [Makefile:146 : all] Erreur 2
   ERROR: Did not suceed to compile Salome/kernel repository
```
Basically, macros `SIZEOF_INT` and `SIZEOF_LONG` are missing from `gcc` point of view, like a missing header file.


### Analysis
After checking where those macros are defined in file `acconfig_pre.h` in omniORB code repository.

When running the `./configure` in the omniORB code repository, did not enable `include/omniORB4/acconfig_pre.h` , it has been commented for an obscur reason. So `acconfig.h` looks like this:
```
/* include/omniORB4/acconfig_pre.h.  Generated from acconfig_pre.h.in by configure.  */
/* include/omniORB4/acconfig_pre.h.in.  Generated from configure.ac by autoheader.  */
...
...
...
/* The size of `bool', as computed by sizeof. */
#define OMNI_SIZEOF_BOOL 1

/* The size of `char', as computed by sizeof. */
#define OMNI_SIZEOF_CHAR 1

/* The size of `double', as computed by sizeof. */
#define OMNI_SIZEOF_DOUBLE 8

/* The size of `float', as computed by sizeof. */
#define OMNI_SIZEOF_FLOAT 4

/* The size of `int', as computed by sizeof. */
#define OMNI_SIZEOF_INT 4

/* The size of `long', as computed by sizeof. */
#define OMNI_SIZEOF_LONG 8

/* The size of `long double', as computed by sizeof. */
#define OMNI_SIZEOF_LONG_DOUBLE 16

/* The size of `long long', as computed by sizeof. */
#define OMNI_SIZEOF_LONG_LONG 8

/* The size of `short', as computed by sizeof. */
#define OMNI_SIZEOF_SHORT 2

/* The size of `unsigned char', as computed by sizeof. */
#define OMNI_SIZEOF_UNSIGNED_CHAR 1

/* The size of `void*', as computed by sizeof. */
#define OMNI_SIZEOF_VOIDP 8

/* The size of `wchar_t', as computed by sizeof. */
#define OMNI_SIZEOF_WCHAR_T 4

/* Define to the type of getsockname's third argument */
#define OMNI_SOCKNAME_SIZE_T socklen_t
```

So the `acconfig_pre.h` is not enabled and only macro `OMNI_SIZEOF_xxxxx` are then defined.


### The fix
This fix aims to, in case those do not exist, rely on the official `OMNI_SIZEOF_xxxxx` macros.