### PR TITLE
Compilation issue with latest Numpy & gcc

### DIFF
--- a/src/DSC/DSC_User/Datastream/Calcium/CalciumC.c
+++ b/src/DSC/DSC_User/Datastream/Calcium/CalciumC.c
@@ -24,6 +24,7 @@
 //  Author : Eric Fayolle (EDF)
 //  Module : KERNEL
 //
+#include "CalciumMacroCInterface.h"
 #include "calcium.h"
 #include "calciumf.h"
 #include "CalciumFortranInt.h"
@@ -42,6 +43,9 @@ InfoType ecp_fint_ (void * component, char* nomVar, float t);
 InfoType ecp_fini_ (void * component, char* nomVar, int i);
 InfoType ecp_efft_ (void * component, char* nomVar, float t);
 InfoType ecp_effi_ (void * component, char* nomVar, int i);
+//Following have been added for declaration
+InfoType ecp_fin_ (void * component, int code);
+InfoType ecp_cd_ (void * component, char* instanceName);
 
 /************************************/
 /* INTERFACES DE LECTURE EN 0 COPIE */
@@ -53,6 +57,23 @@ InfoType ecp_effi_ (void * component, char* nomVar, int i);
 /* L'utilisateur devra appeler ecp_..._free pour désallouer le buffer interne */
 /* Attention en cas de lectures multiples : le buffer retourné est le même */
 /* Attention si les niveaux sont actifs le buffer peut être supprimé automatiquement par calcium. */
+
+CALCIUM_C2CPP_INTERFACE_C_(intc,int,int,float,)
+CALCIUM_C2CPP_INTERFACE_C_(long,long,long,float,)
+
+CALCIUM_C2CPP_INTERFACE_C_(integer,integer,cal_int,float,)
+CALCIUM_C2CPP_INTERFACE_C_(int2integer,integer,int,float,)
+CALCIUM_C2CPP_INTERFACE_C_(long2integer,integer, long,float,)
+
+CALCIUM_C2CPP_INTERFACE_C_(float,float,float,float, )
+CALCIUM_C2CPP_INTERFACE_C_(double,double,double,double,)
+
+CALCIUM_C2CPP_INTERFACE_C_(float2double,double,float,float, )
+
+/*  Fonctionne mais essai suivant pour simplification de Calcium.c CALCIUM_C2CPP_INTERFACE_(bool,bool,);*/
+CALCIUM_C2CPP_INTERFACE_C_(bool,bool,int,float,)
+CALCIUM_C2CPP_INTERFACE_C_(cplx,cplx,float,float,)
+CALCIUM_C2CPP_INTERFACE_C_(str,str,char*,float,)
 
 #define CALCIUM_EXT_LECT_INTERFACE_C_(_name,_timeType,_type,_typeName,_qual) \
   InfoType ecp_##_name (void * component, int mode,                     \

--- a/src/DSC/DSC_User/Datastream/Calcium/CalciumMacroCInterface.h
+++ b/src/DSC/DSC_User/Datastream/Calcium/CalciumMacroCInterface.h
@@ -1,0 +1,63 @@
+// Copyright (C) 2007-2025  CEA, EDF, OPEN CASCADE
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307 USA
+//
+// See http://www.salome-platform.org/ or email : webmaster.salome@opencascade.com
+//
+
+/*  
+File   : CalciumInterface.hxx
+Author : Eric Fayolle (EDF)
+Module : KERNEL
+Modified by : $LastChangedBy$
+Date        : $LastChangedDate: 2007-03-01 13:27:58 +0100 (jeu, 01 mar 2007) $
+Id          : $Id$
+*/
+
+#define _CALCIUM_MACRO_C_INTERFACE_H_
+
+/* template <> struct CalTimeType<float> {
+  typedef float TimeType;
+};
+template <> struct CalTimeType<double> {
+  typedef double TimeType;
+}; */
+
+/****** CALCIUM_C2CPP_INTERFACE_HXX_ :                                  ******/
+/****** Declarations: ecp_lecture_... , ecp_ecriture_..., ecp_free_... ******/
+
+#define CALCIUM_C2CPP_INTERFACE_C_(_name,_porttype,_type,_timeType,_qual)                                                 \
+  InfoType ecp_lecture_##_name (void * component, int dependencyType,                    \
+                                                         _timeType * ti,               \
+                                                         _timeType * tf, long * i,     \
+                                                         const char * const nomvar, size_t bufferLength,          \
+                                                         size_t * nRead, _type _qual ** data );                   \
+                                                                                                                  \
+                                                                                                                  \
+  void ecp_lecture_##_name##_free ( _type _qual * data);                                               \
+                                                                                                                  \
+                                                                                                                  \
+  InfoType ecp_ecriture_##_name (void * component, int dependencyType,                   \
+                                                          _timeType *t,                \
+                                                          long  i,                                                \
+                                                          const char * const nomvar, size_t bufferLength,         \
+                                                          _type _qual * data );                                   \
+  
+
+
+                                                                        
+/****** CALCIUM_C2CPP_INTERFACE_CXX_ :                                ******/                                                                        
+/******Definitions: ecp_lecture_... , ecp_ecriture_..., ecp_free_... ******/
+


### PR DESCRIPTION
Latest gcc (v14.2.1) throws 'error: implicit declaration of function ‘ecp_lecture_str’ [-Wimplicit-function-declaration]' and a few more while compiling CalciumC.c. Thus, the functions have been declared in a separate .h file.
Latest numpy (v2.2.2) headers cause problems with the old code in calcium.i while compiling & it has been updated too.